### PR TITLE
IMAGE_SIZES can now be overridden using LFC_IMAGE_SIZES;

### DIFF
--- a/lfc/settings.py
+++ b/lfc/settings.py
@@ -32,4 +32,4 @@ ORDER_BY_CHOICES = (
     ("-publication_date", _(u"Publication date descending")),
 )
 
-IMAGE_SIZES = ((60, 60), (100, 100), (200, 200), (400, 400), (600, 600), (800, 800))
+IMAGE_SIZES = getattr(settings, 'LFC_IMAGE_SIZES', ((60, 60), (100, 100), (200, 200), (400, 400), (600, 600), (800, 800)))


### PR DESCRIPTION
Kai,

That's the change I proposed at LFC Google groups:
https://groups.google.com/forum/#!topic/django-lfc/-cPtwic2NaQ

This change allows user to override default image sizes using LFC_IMAGE_SIZES in project settings.
That might be useful when using custom sizes, also allows saving some disk space.

Thanks,
Vitaly 
