### PR TITLE
LFC_UPLOAD_FOLDER can be used to change "uploads" folder for uploaded images

### DIFF
--- a/lfc/models.py
+++ b/lfc/models.py
@@ -49,6 +49,7 @@ from lfc.settings import ALLOW_COMMENTS_TRUE
 from lfc.settings import LANGUAGE_CHOICES
 from lfc.settings import ORDER_BY_CHOICES
 from lfc.settings import IMAGE_SIZES
+from lfc.settings import UPLOAD_FOLDER
 
 
 class Application(models.Model):
@@ -1137,7 +1138,7 @@ class Image(models.Model):
     caption = models.CharField(_(u"Caption"), blank=True, max_length=100)
     description = models.TextField(_(u"Description"), blank=True)
     creation_date = models.DateTimeField(_(u"Creation date"), auto_now_add=True)
-    image = ImageWithThumbsField(_(u"Image"), upload_to="uploads", sizes=IMAGE_SIZES)
+    image = ImageWithThumbsField(_(u"Image"), upload_to=UPLOAD_FOLDER, sizes=IMAGE_SIZES)
 
     class Meta:
         ordering = ("position", )

--- a/lfc/settings.py
+++ b/lfc/settings.py
@@ -33,3 +33,4 @@ ORDER_BY_CHOICES = (
 )
 
 IMAGE_SIZES = ((60, 60), (100, 100), (200, 200), (400, 400), (600, 600), (800, 800))
+UPLOAD_FOLDER  = getattr(settings, 'LFC_UPLOAD_FOLDER', 'uploads')


### PR DESCRIPTION
Kai,

this change allows user to override upload folder for images.
For example I want my images to be uploaded to "Nov-2014", then I set:
LFC_UPLOAD_FOLDER = datetime.date.today().strftime('%b-%Y')

Hope that can be useful.

Thanks,
Vitaly
